### PR TITLE
Create application model

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -56,7 +56,7 @@ public class MainApp extends Application {
 
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
-        AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
+        AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getApplicationBookFilePath());
         storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         initLogging(config);

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -34,9 +34,9 @@ public interface Logic {
     ObservableList<Person> getFilteredPersonList();
 
     /**
-     * Returns the user prefs' address book file path.
+     * Returns the user prefs' application book file path.
      */
-    Path getAddressBookFilePath();
+    Path getApplicationBookFilePath();
 
     /**
      * Returns the user prefs' GUI settings.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -65,8 +65,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Path getAddressBookFilePath() {
-        return model.getAddressBookFilePath();
+    public Path getApplicationBookFilePath() {
+        return model.getApplicationBookFilePath();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ApplicationBook.java
+++ b/src/main/java/seedu/address/model/ApplicationBook.java
@@ -1,0 +1,121 @@
+package seedu.address.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.application.Application;
+import seedu.address.model.application.UniqueApplicationList;
+
+/**
+ * Wraps all data at the application-book level.
+ * Duplicates are not allowed (by .isSameApplication comparison).
+ */
+public class ApplicationBook implements ReadOnlyApplicationBook {
+
+    private final UniqueApplicationList applications;
+
+    /*
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
+        applications = new UniqueApplicationList();
+    }
+
+    public ApplicationBook() {}
+
+    /**
+     * Creates an {@code ApplicationBook} using the Applications in the {@code toBeCopied}.
+     */
+    public ApplicationBook(ReadOnlyApplicationBook toBeCopied) {
+        this();
+        resetData(toBeCopied);
+    }
+
+    //// list overwrite operations
+
+    /**
+     * Replaces the contents of the application list with {@code applications}.
+     * {@code applications} must not contain duplicate applications.
+     */
+    public void setApplications(List<Application> applications) {
+        this.applications.setApplications(applications);
+    }
+
+    /**
+     * Resets the existing data of this {@code ApplicationBook} with {@code newData}.
+     */
+    public void resetData(ReadOnlyApplicationBook newData) {
+        requireNonNull(newData);
+
+        setApplications(newData.getApplicationList());
+    }
+
+    //// application-level operations
+
+    /**
+     * Returns true if an application with the same identity as {@code application} exists in the application book.
+     */
+    public boolean hasApplication(Application application) {
+        requireNonNull(application);
+        return applications.contains(application);
+    }
+
+    /**
+     * Adds an application to the application book.
+     * The application must not already exist in the application book.
+     */
+    public void addApplication(Application p) {
+        applications.add(p);
+    }
+
+    /**
+     * Replaces the given application {@code target} in the list with {@code editedApplication}.
+     * {@code target} must exist in the application book.
+     * The application identity of {@code editedApplication} must not be the same as
+     * another existing application in the application book.
+     */
+    public void setApplication(Application target, Application editedApplication) {
+        requireNonNull(editedApplication);
+
+        applications.setApplication(target, editedApplication);
+    }
+
+    /**
+     * Removes {@code key} from this {@code ApplicationBook}.
+     * {@code key} must exist in the application book.
+     */
+    public void removeApplication(Application key) {
+        applications.remove(key);
+    }
+
+    //// util methods
+
+    @Override
+    public String toString() {
+        return applications.asUnmodifiableObservableList().size() + " applications";
+        // TODO: refine later
+    }
+
+    @Override
+    public ObservableList<Application> getApplicationList() {
+        return applications.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ApplicationBook // instanceof handles nulls
+                && applications.equals(((ApplicationBook) other).applications));
+    }
+
+    @Override
+    public int hashCode() {
+        return applications.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/ApplicationModel.java
+++ b/src/main/java/seedu/address/model/ApplicationModel.java
@@ -1,0 +1,88 @@
+package seedu.address.model;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.application.Application;
+
+/**
+ * The API of the Model component.
+ */
+public interface ApplicationModel {
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Application> PREDICATE_SHOW_ALL_APPLICATIONS = unused -> true;
+
+    /**
+     * Replaces user prefs data with the data in {@code userPrefs}.
+     */
+    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
+
+    /**
+     * Returns the user prefs.
+     */
+    ReadOnlyUserPrefs getUserPrefs();
+
+    /**
+     * Returns the user prefs' GUI settings.
+     */
+    GuiSettings getGuiSettings();
+
+    /**
+     * Sets the user prefs' GUI settings.
+     */
+    void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the user prefs' application book file path.
+     */
+    Path getApplicationBookFilePath();
+
+    /**
+     * Sets the user prefs' application book file path.
+     */
+    void setApplicationBookFilePath(Path applicationBookFilePath);
+
+    /**
+     * Replaces application book data with the data in {@code applicationBook}.
+     */
+    void setApplicationBook(ReadOnlyApplicationBook applicationBook);
+
+    /** Returns the ApplicationBook */
+    ReadOnlyApplicationBook getApplicationBook();
+
+    /**
+     * Returns true if an application with the same identity as {@code application} exists in the application book.
+     */
+    boolean hasApplication(Application application);
+
+    /**
+     * Deletes the given application.
+     * The application must exist in the application book.
+     */
+    void deleteApplication(Application target);
+
+    /**
+     * Adds the given application.
+     * {@code application} must not already exist in the application book.
+     */
+    void addApplication(Application application);
+
+    /**
+     * Replaces the given application {@code target} with {@code editedApplication}.
+     * {@code target} must exist in the application book.
+     * The application identity of {@code editedApplication} must not be the same as
+     * another existing application in the application book.
+     */
+    void setApplication(Application target, Application editedApplication);
+
+    /** Returns an unmodifiable view of the filtered application list */
+    ObservableList<Application> getFilteredApplicationList();
+
+    /**
+     * Updates the filter of the filtered application list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredApplicationList(Predicate<Application> predicate);
+}

--- a/src/main/java/seedu/address/model/ApplicationModelManager.java
+++ b/src/main/java/seedu/address/model/ApplicationModelManager.java
@@ -1,0 +1,150 @@
+package seedu.address.model;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.application.Application;
+
+/**
+ * Represents the in-memory model of the application book data.
+ */
+public class ApplicationModelManager implements ApplicationModel {
+    private static final Logger logger = LogsCenter.getLogger(ApplicationModelManager.class);
+
+    private final ApplicationBook applicationBook;
+    private final UserPrefs userPrefs;
+    private final FilteredList<Application> filteredApplications;
+
+    /**
+     * Initializes a ModelManager with the given applicationBook and userPrefs.
+     */
+    public ApplicationModelManager(ReadOnlyApplicationBook applicationBook, ReadOnlyUserPrefs userPrefs) {
+        requireAllNonNull(applicationBook, userPrefs);
+
+        logger.fine("Initializing with application book: " + applicationBook + " and user prefs " + userPrefs);
+
+        this.applicationBook = new ApplicationBook(applicationBook);
+        this.userPrefs = new UserPrefs(userPrefs);
+        filteredApplications = new FilteredList<>(this.applicationBook.getApplicationList());
+    }
+
+    public ApplicationModelManager() {
+        this(new ApplicationBook(), new UserPrefs());
+    }
+
+    //=========== UserPrefs ==================================================================================
+
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        requireNonNull(userPrefs);
+        this.userPrefs.resetData(userPrefs);
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        return userPrefs;
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        return userPrefs.getGuiSettings();
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        requireNonNull(guiSettings);
+        userPrefs.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public Path getApplicationBookFilePath() {
+        return userPrefs.getApplicationBookFilePath();
+    }
+
+    @Override
+    public void setApplicationBookFilePath(Path applicationBookFilePath) {
+        requireNonNull(applicationBookFilePath);
+        userPrefs.setApplicationBookFilePath(applicationBookFilePath);
+    }
+
+    //=========== ApplicationBook ================================================================================
+
+    @Override
+    public void setApplicationBook(ReadOnlyApplicationBook applicationBook) {
+        this.applicationBook.resetData(applicationBook);
+    }
+
+    @Override
+    public ReadOnlyApplicationBook getApplicationBook() {
+        return applicationBook;
+    }
+
+    @Override
+    public boolean hasApplication(Application application) {
+        requireNonNull(application);
+        return applicationBook.hasApplication(application);
+    }
+
+    @Override
+    public void deleteApplication(Application target) {
+        applicationBook.removeApplication(target);
+    }
+
+    @Override
+    public void addApplication(Application application) {
+        applicationBook.addApplication(application);
+        updateFilteredApplicationList(PREDICATE_SHOW_ALL_APPLICATIONS);
+    }
+
+    @Override
+    public void setApplication(Application target, Application editedApplication) {
+        requireAllNonNull(target, editedApplication);
+
+        applicationBook.setApplication(target, editedApplication);
+    }
+
+    //=========== Filtered Application List Accessors =============================================================
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Application} backed by the internal list of
+     * {@code versionedApplicationBook}
+     */
+    @Override
+    public ObservableList<Application> getFilteredApplicationList() {
+        return filteredApplications;
+    }
+
+    @Override
+    public void updateFilteredApplicationList(Predicate<Application> predicate) {
+        requireNonNull(predicate);
+        filteredApplications.setPredicate(predicate);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof ApplicationModelManager)) {
+            return false;
+        }
+
+        // state check
+        ApplicationModelManager other = (ApplicationModelManager) obj;
+        return applicationBook.equals(other.applicationBook)
+                && userPrefs.equals(other.userPrefs)
+                && filteredApplications.equals(other.filteredApplications);
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -35,14 +35,14 @@ public interface Model {
     void setGuiSettings(GuiSettings guiSettings);
 
     /**
-     * Returns the user prefs' address book file path.
+     * Returns the user prefs' application book file path.
      */
-    Path getAddressBookFilePath();
+    Path getApplicationBookFilePath();
 
     /**
-     * Sets the user prefs' address book file path.
+     * Sets the user prefs' application book file path.
      */
-    void setAddressBookFilePath(Path addressBookFilePath);
+    void setApplicationBookFilePath(Path applicationBookFilePath);
 
     /**
      * Replaces address book data with the data in {@code addressBook}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -65,14 +65,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Path getAddressBookFilePath() {
-        return userPrefs.getAddressBookFilePath();
+    public Path getApplicationBookFilePath() {
+        return userPrefs.getApplicationBookFilePath();
     }
 
     @Override
-    public void setAddressBookFilePath(Path addressBookFilePath) {
-        requireNonNull(addressBookFilePath);
-        userPrefs.setAddressBookFilePath(addressBookFilePath);
+    public void setApplicationBookFilePath(Path applicationBookFilePath) {
+        requireNonNull(applicationBookFilePath);
+        userPrefs.setApplicationBookFilePath(applicationBookFilePath);
     }
 
     //=========== AddressBook ================================================================================

--- a/src/main/java/seedu/address/model/ReadOnlyApplicationBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyApplicationBook.java
@@ -1,0 +1,17 @@
+package seedu.address.model;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.application.Application;
+
+/**
+ * Unmodifiable view of an application book
+ */
+public interface ReadOnlyApplicationBook {
+
+    /**
+     * Returns an unmodifiable view of the application list.
+     * This list will not contain any duplicate applications.
+     */
+    ObservableList<Application> getApplicationList();
+
+}

--- a/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
@@ -11,6 +11,6 @@ public interface ReadOnlyUserPrefs {
 
     GuiSettings getGuiSettings();
 
-    Path getAddressBookFilePath();
+    Path getApplicationBookFilePath();
 
 }

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -14,7 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
+    private Path applicationBookFilePath = Paths.get("data" , "applicationbook.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -35,7 +35,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void resetData(ReadOnlyUserPrefs newUserPrefs) {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
-        setAddressBookFilePath(newUserPrefs.getAddressBookFilePath());
+        setApplicationBookFilePath(newUserPrefs.getApplicationBookFilePath());
     }
 
     public GuiSettings getGuiSettings() {
@@ -47,13 +47,13 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.guiSettings = guiSettings;
     }
 
-    public Path getAddressBookFilePath() {
-        return addressBookFilePath;
+    public Path getApplicationBookFilePath() {
+        return applicationBookFilePath;
     }
 
-    public void setAddressBookFilePath(Path addressBookFilePath) {
-        requireNonNull(addressBookFilePath);
-        this.addressBookFilePath = addressBookFilePath;
+    public void setApplicationBookFilePath(Path applicationBookFilePath) {
+        requireNonNull(applicationBookFilePath);
+        this.applicationBookFilePath = applicationBookFilePath;
     }
 
     @Override
@@ -68,19 +68,19 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         UserPrefs o = (UserPrefs) other;
 
         return guiSettings.equals(o.guiSettings)
-                && addressBookFilePath.equals(o.addressBookFilePath);
+                && applicationBookFilePath.equals(o.applicationBookFilePath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings, addressBookFilePath);
+        return Objects.hash(guiSettings, applicationBookFilePath);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings);
-        sb.append("\nLocal data file location : " + addressBookFilePath);
+        sb.append("\nLocal data file location : " + applicationBookFilePath);
         return sb.toString();
     }
 

--- a/src/main/java/seedu/address/storage/AddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/AddressBookStorage.java
@@ -15,7 +15,7 @@ public interface AddressBookStorage {
     /**
      * Returns the file path of the data file.
      */
-    Path getAddressBookFilePath();
+    Path getApplicationBookFilePath();
 
     /**
      * Returns AddressBook data as a {@link ReadOnlyAddressBook}.
@@ -26,7 +26,7 @@ public interface AddressBookStorage {
     Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException, IOException;
 
     /**
-     * @see #getAddressBookFilePath()
+     * @see #getApplicationBookFilePath()
      */
     Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException, IOException;
 

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -27,7 +27,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         this.filePath = filePath;
     }
 
-    public Path getAddressBookFilePath() {
+    public Path getApplicationBookFilePath() {
         return filePath;
     }
 

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -21,7 +21,7 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
 
     @Override
-    Path getAddressBookFilePath();
+    Path getApplicationBookFilePath();
 
     @Override
     Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException, IOException;

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -49,13 +49,13 @@ public class StorageManager implements Storage {
     // ================ AddressBook methods ==============================
 
     @Override
-    public Path getAddressBookFilePath() {
-        return addressBookStorage.getAddressBookFilePath();
+    public Path getApplicationBookFilePath() {
+        return addressBookStorage.getApplicationBookFilePath();
     }
 
     @Override
     public Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException, IOException {
-        return readAddressBook(addressBookStorage.getAddressBookFilePath());
+        return readAddressBook(addressBookStorage.getApplicationBookFilePath());
     }
 
     @Override
@@ -66,7 +66,7 @@ public class StorageManager implements Storage {
 
     @Override
     public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
-        saveAddressBook(addressBook, addressBookStorage.getAddressBookFilePath());
+        saveAddressBook(addressBook, addressBookStorage.getApplicationBookFilePath());
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -116,7 +116,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getApplicationBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,5 @@
       "z" : 99
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "applicationBookFilePath" : "applicationbook.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,5 @@
       "y" : 100
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "applicationBookFilePath" : "applicationbook.json"
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -99,12 +99,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public Path getAddressBookFilePath() {
+        public Path getApplicationBookFilePath() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
+        public void setApplicationBookFilePath(Path addressBookFilePath) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -37,14 +37,14 @@ public class ModelManagerTest {
     @Test
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setAddressBookFilePath(Paths.get("address/book/file/path"));
+        userPrefs.setApplicationBookFilePath(Paths.get("address/book/file/path"));
         userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
         // Modifying userPrefs should not modify modelManager's userPrefs
         UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
-        userPrefs.setAddressBookFilePath(Paths.get("new/address/book/file/path"));
+        userPrefs.setApplicationBookFilePath(Paths.get("new/address/book/file/path"));
         assertEquals(oldUserPrefs, modelManager.getUserPrefs());
     }
 
@@ -61,15 +61,15 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.setAddressBookFilePath(null));
+    public void setApplicationBookFilePath_nullPath_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setApplicationBookFilePath(null));
     }
 
     @Test
-    public void setAddressBookFilePath_validPath_setsAddressBookFilePath() {
+    public void setApplicationBookFilePath_validPath_setsAddressBookFilePath() {
         Path path = Paths.get("address/book/file/path");
-        modelManager.setAddressBookFilePath(path);
-        assertEquals(path, modelManager.getAddressBookFilePath());
+        modelManager.setApplicationBookFilePath(path);
+        assertEquals(path, modelManager.getApplicationBookFilePath());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ModelManagerTest {
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
-        differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
+        differentUserPrefs.setApplicationBookFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
     }
 }

--- a/src/test/java/seedu/address/model/UserPrefsTest.java
+++ b/src/test/java/seedu/address/model/UserPrefsTest.java
@@ -13,9 +13,9 @@ public class UserPrefsTest {
     }
 
     @Test
-    public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
+    public void setApplicationBookFilePath_nullPath_throwsNullPointerException() {
         UserPrefs userPrefs = new UserPrefs();
-        assertThrows(NullPointerException.class, () -> userPrefs.setAddressBookFilePath(null));
+        assertThrows(NullPointerException.class, () -> userPrefs.setApplicationBookFilePath(null));
     }
 
 }

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
+        userPrefs.setApplicationBookFilePath(Paths.get("applicationbook.json"));
         return userPrefs;
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -61,8 +61,8 @@ public class StorageManagerTest {
     }
 
     @Test
-    public void getAddressBookFilePath() {
-        assertNotNull(storageManager.getAddressBookFilePath());
+    public void getApplicationBookFilePath() {
+        assertNotNull(storageManager.getApplicationBookFilePath());
     }
 
 }


### PR DESCRIPTION
This PR creates an `ApplicationModel` that will be used to replace the current `Model`. The new interfaces and classes created in this PR are

* `ReadOnlyApplicationBook` (to replace `ReadOnlyAddressBook`)
* `ApplicationBook` (to replace `AddressBook`)
* `ApplicationModel` (to replace `Model`)
* `ApplicationModelManager` (to replace `ModelManager`)

Later, the rest of the code will need to be edited to use the new interfaces. Use of `Person`s will also need to be replaced with `Application`s. Then finally we can rename `ApplicationModel[Manager]` back to `Model[Manager]` and remove the old files.

Also, this PR edits `ReadOnlyUserPrefs` and `UserPrefs`. Since the changes were minor, I decided to just edit the files directly instead of creating new ones and propagated the changes to the necessary files.

This PR resolves #43 and #47.