### PR TITLE
Fix edit command when application has interview

### DIFF
--- a/src/main/java/seedu/application/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/application/logic/commands/EditCommand.java
@@ -27,7 +27,6 @@ import seedu.application.model.application.Date;
 import seedu.application.model.application.Email;
 import seedu.application.model.application.Position;
 import seedu.application.model.application.Status;
-import seedu.application.model.application.interview.Interview;
 import seedu.application.model.tag.Tag;
 
 /**
@@ -89,17 +88,9 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_APPLICATION);
         }
 
-        Optional<Interview> interview = editedApplication.getInterview();
-        if (interview.isPresent()) {
-            Application editedApplicationWithInterview = new Application(editedApplication, interview.get());
-            model.setApplication(applicationToEdit, editedApplicationWithInterview);
-            model.updateApplicationListWithInterview();
-            return new CommandResult(String.format(MESSAGE_EDIT_APPLICATION_SUCCESS, editedApplicationWithInterview));
-        } else {
-            model.setApplication(applicationToEdit, editedApplication);
-            model.updateApplicationListWithInterview();
-            return new CommandResult(String.format(MESSAGE_EDIT_APPLICATION_SUCCESS, editedApplication));
-        }
+        model.setApplication(applicationToEdit, editedApplication);
+        model.updateApplicationListWithInterview();
+        return new CommandResult(String.format(MESSAGE_EDIT_APPLICATION_SUCCESS, editedApplication));
 
     }
 
@@ -119,12 +110,15 @@ public class EditCommand extends Command {
         Status updatedStatus = editApplicationDescriptor.getStatus().orElse(applicationToEdit.getStatus());
         Set<Tag> updatedTags = editApplicationDescriptor.getTags().orElse(applicationToEdit.getTags());
 
-        if (applicationToEdit.isArchived()) {
-            return new Application(updatedCompany, updatedContact, updatedEmail, updatedPosition,
-                    updatedDate, updatedStatus, updatedTags).setToArchive();
+        Application editedApplication = new Application(updatedCompany, updatedContact, updatedEmail, updatedPosition,
+                updatedDate, updatedStatus, updatedTags);
+        if (applicationToEdit.hasInterview()) {
+            editedApplication = new Application(editedApplication, applicationToEdit.getInterview().get());
         }
-        return new Application(updatedCompany, updatedContact, updatedEmail, updatedPosition, updatedDate,
-                updatedStatus, updatedTags);
+        if (applicationToEdit.isArchived()) {
+            editedApplication = editedApplication.setToArchive();
+        }
+        return editedApplication;
     }
 
     @Override

--- a/src/test/java/seedu/application/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/EditCommandTest.java
@@ -11,8 +11,11 @@ import static seedu.application.logic.commands.CommandTestUtil.assertCommandFail
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.application.logic.commands.CommandTestUtil.showApplicationAtIndex;
 import static seedu.application.testutil.TypicalApplications.getTypicalApplicationBook;
+import static seedu.application.testutil.TypicalApplications.getTypicalApplicationBookWithArchive;
+import static seedu.application.testutil.TypicalApplications.getTypicalApplicationBookWithUpcomingInterview;
 import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_APPLICATION;
 import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND_APPLICATION;
+import static seedu.application.testutil.TypicalIndexes.INDEX_THIRD_APPLICATION;
 
 import org.junit.jupiter.api.Test;
 
@@ -81,6 +84,49 @@ public class EditCommandTest {
         expectedModel.commitApplicationBook();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_applicationWithInterview_success() {
+        Model modelWithInterview = new ModelManager(getTypicalApplicationBookWithUpcomingInterview(), new UserPrefs());
+        Application application = modelWithInterview.getFilteredApplicationList()
+                .get(INDEX_THIRD_APPLICATION.getZeroBased());
+        assert application.hasInterview();
+
+        Application editedApplication = new ApplicationBuilder()
+                .withInterview(application.getInterview().get()).build();
+        EditApplicationDescriptor descriptor = new EditApplicationDescriptorBuilder(editedApplication).build();
+        EditCommand editCommand = new EditCommand(INDEX_THIRD_APPLICATION, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_APPLICATION_SUCCESS, editedApplication);
+
+        Model expectedModel = new ModelManager(
+                new ApplicationBook(modelWithInterview.getApplicationBook()), new UserPrefs());
+        expectedModel.setApplication(application, editedApplication);
+
+        assertCommandSuccess(editCommand, modelWithInterview, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_archivedApplication_success() {
+        Model modelWithArchive = new ModelManager(getTypicalApplicationBookWithArchive(), new UserPrefs());
+        new ListArchiveCommand().execute(modelWithArchive);
+        Application application = modelWithArchive
+                .getFilteredApplicationList().get(INDEX_FIRST_APPLICATION.getZeroBased());
+        assert application.isArchived();
+
+        Application editedApplication = new ApplicationBuilder().withArchiveStatus(true).build();
+        EditApplicationDescriptor descriptor = new EditApplicationDescriptorBuilder(editedApplication).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_APPLICATION, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_APPLICATION_SUCCESS, editedApplication);
+
+        Model expectedModel = new ModelManager(
+                new ApplicationBook(modelWithArchive.getApplicationBook()), new UserPrefs());
+        new ListArchiveCommand().execute(expectedModel);
+        expectedModel.setApplication(application, editedApplication);
+
+        assertCommandSuccess(editCommand, modelWithArchive, expectedMessage, expectedModel);
     }
 
     @Test


### PR DESCRIPTION
The bug was that the code tried to check for the presence of the interview _on the newly created editedApplication_ to decide whether to add an interview to it.

This fixes #170 