### PR TITLE
Fix parse integer overflow error message

### DIFF
--- a/src/main/java/seedu/application/commons/util/StringUtil.java
+++ b/src/main/java/seedu/application/commons/util/StringUtil.java
@@ -5,6 +5,7 @@ import static seedu.application.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.math.BigInteger;
 import java.util.Arrays;
 
 /**
@@ -61,6 +62,26 @@ public class StringUtil {
         try {
             int value = Integer.parseInt(s);
             return value > 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if {@code s} represents a non-zero unsigned integer.
+     * The integer can be of any size and will be parsed using the constructor of {@code BigInteger}.
+     * Will return false for any other non-null string input
+     * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     * @param s The string to check.
+     * @return whether the string is a valid integer.
+     * @throws NullPointerException if {@code s} is null.
+     */
+    public static boolean isNonZeroUnsignedBigInteger(String s) {
+        requireNonNull(s);
+
+        try {
+            BigInteger value = new BigInteger(s);
+            return value.signum() == 1 && !s.startsWith("+"); // "+1" is successfully parsed by BigInteger::new
         } catch (NumberFormatException nfe) {
             return false;
         }

--- a/src/main/java/seedu/application/logic/parser/AddInterviewCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/AddInterviewCommandParser.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 import seedu.application.commons.core.index.Index;
 import seedu.application.logic.commands.AddInterviewCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.logic.parser.exceptions.ParseIntegerOverflowException;
 import seedu.application.model.application.interview.Interview;
 import seedu.application.model.application.interview.InterviewDate;
 import seedu.application.model.application.interview.InterviewTime;
@@ -34,6 +35,9 @@ public class AddInterviewCommandParser implements Parser<AddInterviewCommand> {
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseIntegerOverflowException e) {
+            // Rethrow exception if index formatted correctly but too large to store in an int
+            throw e;
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInterviewCommand.MESSAGE_USAGE),
                     pe);

--- a/src/main/java/seedu/application/logic/parser/ArchiveCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/ArchiveCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.application.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import seedu.application.commons.core.index.Index;
 import seedu.application.logic.commands.ArchiveCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.logic.parser.exceptions.ParseIntegerOverflowException;
 
 /**
  * Parses input arguments and creates a new ArchiveCommand object.
@@ -20,6 +21,9 @@ public class ArchiveCommandParser implements Parser<ArchiveCommand> {
         try {
             Index index = ParserUtil.parseIndex(args);
             return new ArchiveCommand(index);
+        } catch (ParseIntegerOverflowException e) {
+            // Rethrow exception if index formatted correctly but too large to store in an int
+            throw e;
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ArchiveCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/application/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/DeleteCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.application.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import seedu.application.commons.core.index.Index;
 import seedu.application.logic.commands.DeleteCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.logic.parser.exceptions.ParseIntegerOverflowException;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object.
@@ -20,6 +21,9 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);
+        } catch (ParseIntegerOverflowException e) {
+            // Rethrow exception if index formatted correctly but too large to store in an int
+            throw e;
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/application/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/EditCommandParser.java
@@ -19,6 +19,7 @@ import seedu.application.commons.core.index.Index;
 import seedu.application.logic.commands.EditCommand;
 import seedu.application.logic.commands.EditCommand.EditApplicationDescriptor;
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.logic.parser.exceptions.ParseIntegerOverflowException;
 import seedu.application.model.tag.Tag;
 
 /**
@@ -39,6 +40,9 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseIntegerOverflowException e) {
+            // Rethrow exception if index formatted correctly but too large to store in an int
+            throw e;
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }

--- a/src/main/java/seedu/application/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/application/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import seedu.application.commons.core.index.Index;
 import seedu.application.commons.util.StringUtil;
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.logic.parser.exceptions.ParseIntegerOverflowException;
 import seedu.application.model.application.Company;
 import seedu.application.model.application.Contact;
 import seedu.application.model.application.Date;
@@ -27,15 +28,21 @@ import seedu.application.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INDEX_OVERFLOW = "The index provided is too big to process.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     * @throws ParseIntegerOverflowException if the specified index is valid but does not fit in an int.
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+            if (StringUtil.isNonZeroUnsignedBigInteger(trimmedIndex)) {
+                // Index is formatted correctly but too big to store in an int
+                throw new ParseIntegerOverflowException(MESSAGE_INDEX_OVERFLOW);
+            }
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));

--- a/src/main/java/seedu/application/logic/parser/RemoveInterviewCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/RemoveInterviewCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.application.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import seedu.application.commons.core.index.Index;
 import seedu.application.logic.commands.RemoveInterviewCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.logic.parser.exceptions.ParseIntegerOverflowException;
 
 /**
  * Parses input arguments and creates a new RemoveInterviewCommand object
@@ -20,6 +21,9 @@ public class RemoveInterviewCommandParser implements Parser<RemoveInterviewComma
         try {
             Index index = ParserUtil.parseIndex(args);
             return new RemoveInterviewCommand(index);
+        } catch (ParseIntegerOverflowException e) {
+            // Rethrow exception if index formatted correctly but too large to store in an int
+            throw e;
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveInterviewCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/application/logic/parser/RetrieveCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/RetrieveCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.application.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import seedu.application.commons.core.index.Index;
 import seedu.application.logic.commands.RetrieveCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.logic.parser.exceptions.ParseIntegerOverflowException;
 
 /**
  * Parses input arguments and creates a new RetrieveCommand object.
@@ -20,6 +21,9 @@ public class RetrieveCommandParser implements Parser<RetrieveCommand> {
         try {
             Index index = ParserUtil.parseIndex(args);
             return new RetrieveCommand(index);
+        } catch (ParseIntegerOverflowException e) {
+            // Rethrow exception if index formatted correctly but too large to store in an int
+            throw e;
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, RetrieveCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/application/logic/parser/exceptions/ParseIntegerOverflowException.java
+++ b/src/main/java/seedu/application/logic/parser/exceptions/ParseIntegerOverflowException.java
@@ -1,0 +1,10 @@
+package seedu.application.logic.parser.exceptions;
+
+/**
+ * Represents a parse error caused by attempting to parse an integer that does not fit in an int.
+ */
+public class ParseIntegerOverflowException extends ParseException {
+    public ParseIntegerOverflowException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/seedu/application/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/application/commons/util/StringUtilTest.java
@@ -38,13 +38,46 @@ public class StringUtilTest {
         assertFalse(StringUtil.isNonZeroUnsignedInteger("1 0")); // Spaces in the middle
 
         // EP: number larger than Integer.MAX_VALUE
-        assertFalse(StringUtil.isNonZeroUnsignedInteger(Long.toString(Integer.MAX_VALUE + 1)));
+        assertFalse(StringUtil.isNonZeroUnsignedInteger(Long.toString((long) Integer.MAX_VALUE + 1)));
 
         // EP: valid numbers, should return true
         assertTrue(StringUtil.isNonZeroUnsignedInteger("1")); // Boundary value
         assertTrue(StringUtil.isNonZeroUnsignedInteger("10"));
     }
 
+    //---------------- Tests for isNonZeroUnsignedBigInteger --------------------------------------
+
+    @Test
+    public void isNonZeroUnsignedBigInteger() {
+
+        // EP: empty strings
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger("")); // Boundary value
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger("  "));
+
+        // EP: not a number
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger("a"));
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger("aaa"));
+
+        // EP: zero
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger("0"));
+
+        // EP: zero as prefix
+        assertTrue(StringUtil.isNonZeroUnsignedBigInteger("01"));
+
+        // EP: signed numbers
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger("-1"));
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger("+1"));
+
+        // EP: numbers with white space
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger(" 10 ")); // Leading/trailing spaces
+        assertFalse(StringUtil.isNonZeroUnsignedBigInteger("1 0")); // Spaces in the middle
+
+        // EP: valid numbers, should return true
+        assertTrue(StringUtil.isNonZeroUnsignedBigInteger("1")); // Boundary value
+        assertTrue(StringUtil.isNonZeroUnsignedBigInteger("10"));
+        // number larger than Integer.MAX_VALUE also return true
+        assertTrue(StringUtil.isNonZeroUnsignedBigInteger(Long.toString((long) Integer.MAX_VALUE + 1)));
+    }
 
     //---------------- Tests for containsWordIgnoreCase --------------------------------------
 

--- a/src/test/java/seedu/application/logic/parser/AddInterviewCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/AddInterviewCommandParserTest.java
@@ -15,6 +15,7 @@ import static seedu.application.logic.commands.CommandTestUtil.VALID_LOCATION_GO
 import static seedu.application.logic.commands.CommandTestUtil.VALID_ROUND_GOOGLE;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.application.logic.parser.ParserUtil.MESSAGE_INDEX_OVERFLOW;
 import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_APPLICATION;
 import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND_APPLICATION;
 
@@ -62,6 +63,9 @@ public class AddInterviewCommandParserTest {
 
         // zero index
         assertParseFailure(parser, "0" + userInput, MESSAGE_INVALID_FORMAT);
+
+        // index greater than Integer.MAX_VALUE
+        assertParseFailure(parser, ((long) Integer.MAX_VALUE + 1) + userInput, MESSAGE_INDEX_OVERFLOW);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/application/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/EditCommandParserTest.java
@@ -37,6 +37,7 @@ import static seedu.application.logic.commands.CommandTestUtil.VALID_TAG_TECH_CO
 import static seedu.application.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.application.logic.parser.ParserUtil.MESSAGE_INDEX_OVERFLOW;
 import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_APPLICATION;
 import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND_APPLICATION;
 import static seedu.application.testutil.TypicalIndexes.INDEX_THIRD_APPLICATION;
@@ -83,6 +84,9 @@ public class EditCommandParserTest {
 
         // zero index
         assertParseFailure(parser, "0" + COMPANY_DESC_FACEBOOK, MESSAGE_INVALID_FORMAT);
+
+        // index greater than Integer.MAX_VALUE
+        assertParseFailure(parser, ((long) Integer.MAX_VALUE + 1) + COMPANY_DESC_FACEBOOK, MESSAGE_INDEX_OVERFLOW);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
@@ -2,6 +2,7 @@ package seedu.application.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.application.logic.parser.ParserUtil.MESSAGE_INDEX_OVERFLOW;
 import static seedu.application.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.application.testutil.Assert.assertThrows;
 import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_APPLICATION;
@@ -14,6 +15,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.logic.parser.exceptions.ParseIntegerOverflowException;
 import seedu.application.model.application.Company;
 import seedu.application.model.application.Contact;
 import seedu.application.model.application.Date;
@@ -41,13 +43,13 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () -> ParserUtil.parseIndex("10 a"));
     }
 
     @Test
-    public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+    public void parseIndex_outOfRangeInput_throwsParseIntegerOverflowException() {
+        assertThrows(ParseIntegerOverflowException.class, MESSAGE_INDEX_OVERFLOW, ()
+            -> ParserUtil.parseIndex(Long.toString((long) Integer.MAX_VALUE + 1)));
     }
 
     @Test


### PR DESCRIPTION
Fixes the message that is shown if a user enters a valid index that overflows an int.
Now the message shown is "The index provided is too big to process."
The behaviour in any other case remains the same.

This fixes #136 and fixes #154