### PR TITLE
Fix interview time issue

### DIFF
--- a/src/main/java/seedu/application/model/application/interview/Interview.java
+++ b/src/main/java/seedu/application/model/application/interview/Interview.java
@@ -3,7 +3,6 @@ package seedu.application.model.application.interview;
 import static seedu.application.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Objects;
 
 /**
@@ -12,13 +11,12 @@ import java.util.Objects;
  */
 public class Interview {
 
+    private static final long DURATION = 1;
     // Identity fields
     private final Round round;
     private final InterviewDate interviewDate;
     private final InterviewTime interviewTime;
     private final Location location;
-    private static final long DURATION = 1;
-
 
     /**
      * Every field must be present and not null.
@@ -66,8 +64,8 @@ public class Interview {
 
         LocalDateTime otherInterviewDateTime = getInterviewDateTime(otherInterview);
         LocalDateTime thisInterviewDateTime = getInterviewDateTime(this);
-        return otherInterviewDateTime.equals(thisInterviewDateTime) ||
-                ((otherInterviewDateTime.isAfter(thisInterviewDateTime)
+        return otherInterviewDateTime.equals(thisInterviewDateTime)
+                || ((otherInterviewDateTime.isAfter(thisInterviewDateTime)
                 && otherInterviewDateTime.isBefore(thisInterviewDateTime.plusHours(DURATION)))
                 || (thisInterviewDateTime.isAfter(otherInterviewDateTime)
                 && thisInterviewDateTime.isBefore(otherInterviewDateTime.plusHours(DURATION))));

--- a/src/main/java/seedu/application/model/application/interview/Interview.java
+++ b/src/main/java/seedu/application/model/application/interview/Interview.java
@@ -3,6 +3,7 @@ package seedu.application.model.application.interview;
 import static seedu.application.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Objects;
 
 /**
@@ -16,6 +17,7 @@ public class Interview {
     private final InterviewDate interviewDate;
     private final InterviewTime interviewTime;
     private final Location location;
+    private static final long DURATION = 1;
 
 
     /**
@@ -57,10 +59,24 @@ public class Interview {
         if (otherInterview == this) {
             return true;
         }
+        if (otherInterview == null) {
+            return false;
+        }
 
+        /*
         return otherInterview != null
                 && otherInterview.getInterviewDate().equals(getInterviewDate())
                 && otherInterview.getInterviewTime().isWithin(getInterviewTime());
+                getInterviewDateTime(otherInterview)
+                getInterviewDateTime(this)
+
+         */
+        LocalDateTime otherInterviewDateTime = getInterviewDateTime(otherInterview);
+        LocalDateTime thisInterviewDateTime = getInterviewDateTime(this);
+        return ((otherInterviewDateTime.isAfter(thisInterviewDateTime)
+                && otherInterviewDateTime.isBefore(thisInterviewDateTime.plusHours(DURATION)))
+                || (thisInterviewDateTime.isAfter(otherInterviewDateTime)
+                && thisInterviewDateTime.isBefore(otherInterviewDateTime.plusHours(DURATION))));
     }
 
     /**

--- a/src/main/java/seedu/application/model/application/interview/Interview.java
+++ b/src/main/java/seedu/application/model/application/interview/Interview.java
@@ -52,7 +52,8 @@ public class Interview {
     }
 
     /**
-     * Returns true if both interviews have the same date and time is within one hour of one another.
+     * Returns true if interview with one hour duration overlaps with one another.
+     * This supports the checking of interviews across different date.
      * This defines a weaker notion of equality between two applications.
      */
     public boolean isOnSameTime(Interview otherInterview) {
@@ -63,17 +64,10 @@ public class Interview {
             return false;
         }
 
-        /*
-        return otherInterview != null
-                && otherInterview.getInterviewDate().equals(getInterviewDate())
-                && otherInterview.getInterviewTime().isWithin(getInterviewTime());
-                getInterviewDateTime(otherInterview)
-                getInterviewDateTime(this)
-
-         */
         LocalDateTime otherInterviewDateTime = getInterviewDateTime(otherInterview);
         LocalDateTime thisInterviewDateTime = getInterviewDateTime(this);
-        return ((otherInterviewDateTime.isAfter(thisInterviewDateTime)
+        return otherInterviewDateTime.equals(thisInterviewDateTime) ||
+                ((otherInterviewDateTime.isAfter(thisInterviewDateTime)
                 && otherInterviewDateTime.isBefore(thisInterviewDateTime.plusHours(DURATION)))
                 || (thisInterviewDateTime.isAfter(otherInterviewDateTime)
                 && thisInterviewDateTime.isBefore(otherInterviewDateTime.plusHours(DURATION))));

--- a/src/main/java/seedu/application/model/application/interview/InterviewTime.java
+++ b/src/main/java/seedu/application/model/application/interview/InterviewTime.java
@@ -17,7 +17,6 @@ public class InterviewTime {
     public static final String MESSAGE_CONSTRAINTS = "Time should be in the format of HHMM, ranging from 0000 to 2359.";
     public static final DateTimeFormatter COMMAND_TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmm");
     public static final DateTimeFormatter DISPLAY_TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_TIME;
-    private static final long DURATION = 1;
     private static final String INVALID_MIDNIGHT = "^2400$";
     public final LocalTime value;
 
@@ -46,20 +45,6 @@ public class InterviewTime {
 
     private LocalTime parseLocalTime(String timeString) {
         return LocalTime.parse(timeString, COMMAND_TIME_FORMATTER);
-    }
-
-    /**
-     * Returns true if the one's interview time falls within the range of one hour of another interview's time.
-     *
-     * @param otherTime another interviewTime to be checked.
-     * @return true if the one's interview time falls within the range of one hour of another interview's time.
-     */
-    public boolean isWithin(InterviewTime otherTime) {
-        return otherTime.value.equals(this.value)
-                || ((otherTime.value.isAfter(this.value)
-                && otherTime.value.isBefore(this.value.plusHours(DURATION)))
-                || (this.value.isAfter(otherTime.value)
-                && this.value.isBefore(otherTime.value.plusHours(DURATION))));
     }
 
     /**

--- a/src/main/java/seedu/application/model/application/interview/InterviewTime.java
+++ b/src/main/java/seedu/application/model/application/interview/InterviewTime.java
@@ -14,10 +14,11 @@ import java.time.format.DateTimeParseException;
 public class InterviewTime {
 
 
-    public static final String MESSAGE_CONSTRAINTS = "Time should be in the format of HHMM";
+    public static final String MESSAGE_CONSTRAINTS = "Time should be in the format of HHMM, ranging from 0000 to 2359.";
     public static final DateTimeFormatter COMMAND_TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmm");
     public static final DateTimeFormatter DISPLAY_TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_TIME;
     private static final long DURATION = 1;
+    private static final String INVALID_MIDNIGHT = "^2400$";
     public final LocalTime value;
 
     /**
@@ -37,10 +38,10 @@ public class InterviewTime {
     public static boolean isValidTime(String test) {
         try {
             COMMAND_TIME_FORMATTER.parse(test);
-            return true;
         } catch (DateTimeParseException e) {
             return false;
         }
+        return !test.matches(INVALID_MIDNIGHT);
     }
 
     private LocalTime parseLocalTime(String timeString) {

--- a/src/test/java/seedu/application/model/application/interview/InterviewTest.java
+++ b/src/test/java/seedu/application/model/application/interview/InterviewTest.java
@@ -40,6 +40,20 @@ public class InterviewTest {
                 .build();
         assertFalse(INTERVIEW_GOOGLE.isOnSameTime(editedGoogleInterview));
 
+        // across different date but within one hour -> return true
+        Interview editedFacebookInterview = new InterviewBuilder(INTERVIEW_FACEBOOK).withInterviewDate("2022-10-02")
+                .withInterviewTime("0001").build();
+        editedGoogleInterview = new InterviewBuilder(INTERVIEW_GOOGLE).withInterviewDate("2022-10-01")
+                .withInterviewTime("2359").build();
+        assertTrue(editedFacebookInterview.isOnSameTime(editedGoogleInterview));
+
+        // across different date but one hour apart -> return false
+        editedFacebookInterview = new InterviewBuilder(INTERVIEW_FACEBOOK).withInterviewDate("2022-10-02")
+                .withInterviewTime("0159").build();
+        editedGoogleInterview = new InterviewBuilder(INTERVIEW_GOOGLE).withInterviewDate("2022-10-01")
+                .withInterviewTime("2359").build();
+        assertFalse(editedFacebookInterview.isOnSameTime(editedGoogleInterview));
+
     }
 
     @Test

--- a/src/test/java/seedu/application/model/application/interview/InterviewTimeTest.java
+++ b/src/test/java/seedu/application/model/application/interview/InterviewTimeTest.java
@@ -47,15 +47,6 @@ public class InterviewTimeTest {
     }
 
     @Test
-    public void isWithin() {
-        assertFalse(new InterviewTime("1100").isWithin(new InterviewTime("0900")));
-        assertFalse(new InterviewTime("2359").isWithin(new InterviewTime("2259")));
-
-        assertTrue(new InterviewTime("0500").isWithin(new InterviewTime("0559")));
-        assertTrue(new InterviewTime("1756").isWithin(new InterviewTime("1700")));
-
-    }
-    @Test
     public void interviewTime() {
         assertEquals(new InterviewTime("2359").toString(), "23:59");
         assertEquals(new InterviewTime("0900").toString(), "09:00");


### PR DESCRIPTION
- Add checks for duplicated interviews across two neighboring dates.
- Add checks for interview time of `2400` 

Resolves #193 and #192 