### PR TITLE
Fix email format message

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -116,9 +116,26 @@ Format: `add c/COMPANY ct/CONTACT e/EMAIL p/POSITION d/DATE_APPLIED s/STATUS [t/
 <br>
 1. <code>DATE_APPLIED</code> must be specified in the format <em>yyyy-MM-dd</em>.<br>
 2. <code>CONTACT</code> must be 5-15 digits long.<br>
-3. <code>STATUS</code> must be one of the following: <b>pending</b>, <b>interview</b>, <b>offered</b>, <b>rejected</b>.<br>
-4. Do note that an <b>interview</b> <code>STATUS</code> does not imply that the application has an associated interview in the interview list.<br>
-5. Tags must be alphanumeric and cannot contain spaces.
+3. Emails should be of the format local-part@domain and adhere to the following constraints:
+<ol>
+    <li>
+    The local-part should only contain alphanumeric characters and these special characters, excluding the parentheses, (+_.-).<br>
+    The local-part may not start or end with any special characters, nor can it contain consecutive special characters.
+    </li>
+    <li>
+    This is followed by a '@' and then a domain name. The domain name is made up of domain labels separated by periods.<br>
+    The domain name must:
+    <ul>
+        <li>
+        have each domain label consist of alphanumeric characters, separated only by singular hyphens, if any</li>
+        <li>have each domain label start and end with alphanumeric characters</li>
+        <li>end with a domain label that contains at least 2 consecutive alphanumeric characters</li>
+    </ul>
+    </li>
+</ol>
+4. <code>STATUS</code> must be one of the following: <b>pending</b>, <b>interview</b>, <b>offered</b>, <b>rejected</b>.<br>
+5. Do note that an <b>interview</b> <code>STATUS</code> does not imply that the application has an associated interview in the interview list.<br>
+6. Tags must be alphanumeric and cannot contain spaces.
 </div>
 
 Examples:

--- a/src/main/java/seedu/application/model/application/Email.java
+++ b/src/main/java/seedu/application/model/application/Email.java
@@ -13,14 +13,16 @@ public class Email {
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
-            + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
-            + "characters.\n"
+            + "the parentheses, (" + SPECIAL_CHARACTERS + ").\nThe local-part may not start or end with any special "
+            + "characters, nor can it contain consecutive special characters.\n"
             + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
+            + "    - have each domain label consist of alphanumeric characters,"
+            + " separated only by singular hyphens, if any\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
+            + "    - end with a domain label that contains at least 2 consecutive alphanumeric characters\n";
+
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"


### PR DESCRIPTION
This PR makes the error message for the email format more accurately reflect what the validation actually checks for and also adds the format instructions to the UG.

This resolves #204 and resolves #206 